### PR TITLE
fix inotify event printing

### DIFF
--- a/inotify/inotify_linux.go
+++ b/inotify/inotify_linux.go
@@ -221,7 +221,7 @@ func (e *Event) String() string {
 
 	m := e.Mask
 	for _, b := range eventBits {
-		if m&b.Value != 0 {
+		if m&b.Value == b.Value {
 			m &^= b.Value
 			events += "|" + b.Name
 		}


### PR DESCRIPTION
Only print a mask name if that exact mask is found. i.e., a mask consisting just
of IN_CLOSE_WRITE should print IN_CLOSE_WRITE, not IN_CLOSE.