### PR TITLE
Allow watches that exist in the watches map to be removed even if the…

### DIFF
--- a/inotify/inotify_linux.go
+++ b/inotify/inotify_linux.go
@@ -140,7 +140,7 @@ func (w *Watcher) RemoveWatch(path string) error {
 		return errors.New(fmt.Sprintf("can't remove non-existent inotify watch for: %s", path))
 	}
 	success, errno := syscall.InotifyRmWatch(w.fd, watch.wd)
-	if success == -1 {
+	if !ok && success == -1 {
 		return os.NewSyscallError("inotify_rm_watch", errno)
 	}
 	delete(w.watches, path)


### PR DESCRIPTION
… watch isn't registered with inotify


What version of Go are you using (go version)?

  go version go1.6.1 linux/amd64

What operating system and processor architecture are you using?

  CentOS 6
  Intel Core 2 Duo
  2.6.32-431.20.3.el6.centos.plus.x86_64 #1 SMP Thu Jun 19 23:04:15 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux

What did you do?

  I deleted a directory that was being watched.

What did you expect to see?

  If a directory is deleted I expect to be able to watch another directory with that gets created with the same name.

What did you see instead?

  If a watched directory is deleted from the OS it will never be removed from the watches map which cases a directory with the same name to never be able to be watched again during the programs execution

  I created a gist here. You can test it against the current code and my pull request. https://gist.github.com/agorman/000e5aca46827057accc8312bf55d989
