### PR TITLE
exp/shiny/driver/gldriver: identify race condition

### DIFF
--- a/shiny/driver/gldriver/x11.go
+++ b/shiny/driver/gldriver/x11.go
@@ -70,7 +70,7 @@ func showWindow(w *windowImpl) {
 	}
 	w.ctx = <-retc
 	w.glctxMu.Lock()
-	w.glctx, w.worker = glctx, worker
+	w.glctx, w.worker = glctx, worker // TODO: Races with onConfigure
 	w.glctxMu.Unlock()
 	go drawLoop(w)
 }
@@ -276,7 +276,7 @@ func onConfigure(id uintptr, x, y, width, height, displayWidth, displayWidthMM i
 	}()
 
 	w.lifecycler.SetVisible(x+width > 0 && y+height > 0)
-	w.lifecycler.SendEvent(w, w.glctx)
+	w.lifecycler.SendEvent(w, w.glctx) // TODO: Races with showWindow
 
 	const (
 		mmPerInch = 25.4


### PR DESCRIPTION
golang.org/x/exp/shiny/example/basicgl exhibits an occasional race condition:

```
$ cd $GOPATH/src/golang.org/x/exp/shiny/example/basicgl
$ go build -race main.go
$ ./main

==================
WARNING: DATA RACE
Write at 0x00c4200fa0c8 by goroutine 6:
  golang.org/x/exp/shiny/driver/gldriver.showWindow()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/x11.go:73 +0x1f3
  golang.org/x/exp/shiny/driver/gldriver.(*screenImpl).NewWindow()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/screen.go:145 +0x33d
  golang.org/x/exp/shiny/widget.RunWindow()
      /home/arne/src/golang.org/x/exp/shiny/widget/widget.go:77 +0xb1
  main.main.func1()
      /home/arne/src/golang.org/x/exp/shiny/example/basicgl/main.go:51 +0x4cd
  golang.org/x/exp/shiny/driver/gldriver.main.func1()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/x11.go:127 +0x5b

Previous read at 0x00c4200fa0c8 by main goroutine:
  golang.org/x/exp/shiny/driver/gldriver.onConfigure()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/x11.go:279 +0x1ac
  golang.org/x/exp/shiny/driver/gldriver._cgoexpwrap_0cf67038b08c_onConfigure()
      golang.org/x/exp/shiny/driver/gldriver/_obj/_cgo_gotypes.go:221 +0x68
  runtime.call32()
      /home/arne/bin/go/src/runtime/asm_amd64.s:479 +0x4b
  golang.org/x/exp/shiny/driver/gldriver.main()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/x11.go:162 +0x5d6
  golang.org/x/exp/shiny/driver/gldriver.Main()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/gldriver.go:26 +0x3c
  main.main()
      /home/arne/src/golang.org/x/exp/shiny/example/basicgl/main.go:54 +0x3a

Goroutine 6 (running) created at:
  golang.org/x/exp/shiny/driver/gldriver.main()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/x11.go:129 +0x2ae
  golang.org/x/exp/shiny/driver/gldriver.Main()
      /home/arne/src/golang.org/x/exp/shiny/driver/gldriver/gldriver.go:26 +0x3c
  main.main()
      /home/arne/src/golang.org/x/exp/shiny/example/basicgl/main.go:54 +0x3a
==================
```

Sometimes the same code even segfaults:
```
$ ./main
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x498 pc=0x49799c]

goroutine 21 [running]:
panic(0x56e6c0, 0xc42000c140)
	/home/arne/bin/go/src/runtime/panic.go:500 +0x1ae
golang.org/x/exp/shiny/driver/gldriver.onConfigure.func1(0xc420110000, 0x58900000358)
	/home/arne/src/golang.org/x/exp/shiny/driver/gldriver/x11.go:274 +0x6c
created by golang.org/x/exp/shiny/driver/gldriver.onConfigure
	/home/arne/src/golang.org/x/exp/shiny/driver/gldriver/x11.go:276 +0x14d
```

This behaviour is flaky and sometimes hard to reproduce. I use the i3 window manager, which re-sizes windows as soon as they are created.

My system:
```
$ go version
go version go1.7.1 linux/amd64

$ uname -a
Linux stormkern 4.4.0-31-generic #50-Ubuntu SMP Wed Jul 13 00:07:12 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux

$ nvidia-smi
Fri Jan  6 22:12:37 2017       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 367.57                 Driver Version: 367.57                    |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  GeForce GTX 1070    Off  | 0000:01:00.0      On |                  N/A |
| 27%   33C    P8     7W / 151W |    136MiB /  8112MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID  Type  Process name                               Usage      |
|=============================================================================|
|    0      1049    G   /usr/lib/xorg/Xorg                             132MiB |
|    0      8639    G   /usr/lib/firefox/plugin-container                1MiB |
+-----------------------------------------------------------------------------+
```