### PR TITLE
shiny/driver/gldriver: update the open gl context after making it current

### DIFF
--- a/shiny/driver/gldriver/cocoa.m
+++ b/shiny/driver/gldriver/cocoa.m
@@ -34,6 +34,7 @@ enum
 void makeCurrentContext(uintptr_t context) {
 	NSOpenGLContext* ctx = (NSOpenGLContext*)context;
 	[ctx makeCurrentContext];
+	[ctx update];
 }
 
 void flushContext(uintptr_t context) {


### PR DESCRIPTION
This seems necessary (at least on Mojave). Otherwise, the window seems to have the wrong viewport until it is moved or resized.