### PR TITLE
shiny/driver/internal/win32: handle syskey messages

### DIFF
--- a/shiny/driver/internal/win32/key.go
+++ b/shiny/driver/internal/win32/key.go
@@ -332,14 +332,14 @@ func sendKeyEvent(hwnd syscall.Handle, uMsg uint32, wParam, lParam uintptr) (lRe
 		Modifiers: keyModifiers(),
 	}
 	switch uMsg {
-	case _WM_KEYDOWN:
+	case _WM_KEYDOWN, _WM_SYSKEYDOWN:
 		const prevMask = 1 << 30
 		if repeat := lParam&prevMask == prevMask; repeat {
 			e.Direction = key.DirNone
 		} else {
 			e.Direction = key.DirPress
 		}
-	case _WM_KEYUP:
+	case _WM_KEYUP, _WM_SYSKEYUP:
 		e.Direction = key.DirRelease
 	default:
 		panic(fmt.Sprintf("win32: unexpected key message: %d", uMsg))

--- a/shiny/driver/internal/win32/win32.go
+++ b/shiny/driver/internal/win32/win32.go
@@ -333,7 +333,8 @@ var windowMsgs = map[uint32]func(hwnd syscall.Handle, uMsg uint32, wParam, lPara
 
 	_WM_KEYDOWN: sendKeyEvent,
 	_WM_KEYUP:   sendKeyEvent,
-	// TODO case _WM_SYSKEYDOWN, _WM_SYSKEYUP:
+	_WM_SYSKEYDOWN: sendKeyEvent,
+	_WM_SYSKEYUP: sendKeyEvent,
 }
 
 func AddWindowMsg(fn func(hwnd syscall.Handle, uMsg uint32, wParam, lParam uintptr)) uint32 {


### PR DESCRIPTION
Under certain circumstances Windows sends `_WM_SYSKEYDOWN` and `_WM_SYSKEYUP` messages instead of `_WM_KEYDOWN` and `_WM_KEYUP` messages.

This handles the `SYSKEY` messages in the same way as the other messages, to be able to forward all key events to the application.

The exact circumstances are when the key is F10 or when the ALT key is currently pressed while another key is pressed. This behavior is documented in the Windows documentation [here](https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-syskeydown).

Fixes golang/go#36213.