### PR TITLE
shiny/driver/x11driver: fallback to regular pixmaps if SHM is unavaiable

### DIFF
--- a/shiny/driver/x11driver/buffer.go
+++ b/shiny/driver/x11driver/buffer.go
@@ -16,9 +16,12 @@ import (
 	"github.com/BurntSushi/xgb/render"
 	"github.com/BurntSushi/xgb/shm"
 	"github.com/BurntSushi/xgb/xproto"
-
 	"golang.org/x/exp/shiny/driver/internal/swizzle"
 )
+
+type bufferUploader interface {
+	upload(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle)
+}
 
 type bufferImpl struct {
 	s *screenImpl

--- a/shiny/driver/x11driver/buffer_fallback.go
+++ b/shiny/driver/x11driver/buffer_fallback.go
@@ -1,0 +1,96 @@
+package x11driver
+
+import (
+	"image"
+	"log"
+
+	"github.com/BurntSushi/xgb"
+	"github.com/BurntSushi/xgb/xproto"
+	"golang.org/x/exp/shiny/driver/internal/swizzle"
+)
+
+const (
+	xPutImageReqSizeMax   = (1 << 16) * 4
+	xPutImageReqSizeFixed = 28
+	xPutImageReqDataSize  = xPutImageReqSizeMax - xPutImageReqSizeFixed
+)
+
+type bufferFailbackImpl struct {
+	xc *xgb.Conn
+
+	buf  []byte
+	rgba image.RGBA
+	size image.Point
+}
+
+func (b *bufferFailbackImpl) Release()                {}
+func (b *bufferFailbackImpl) Size() image.Point       { return b.size }
+func (b *bufferFailbackImpl) Bounds() image.Rectangle { return image.Rectangle{Max: b.size} }
+func (b *bufferFailbackImpl) RGBA() *image.RGBA       { return &b.rgba }
+
+func (b *bufferFailbackImpl) preUpload() {
+	// Check that the program hasn't tried to modify the rgba field via the
+	// pointer returned by the bufferImpl.RGBA method. This check doesn't catch
+	// 100% of all cases; it simply tries to detect some invalid uses of a
+	// screen.Buffer such as:
+	//	*buffer.RGBA() = anotherImageRGBA
+	if len(b.buf) != 0 && len(b.rgba.Pix) != 0 && &b.buf[0] != &b.rgba.Pix[0] {
+		panic("x11driver: invalid Buffer.RGBA modification")
+	}
+
+	swizzle.BGRA(b.buf)
+}
+
+func (b *bufferFailbackImpl) upload(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle) {
+	originalSRMin := sr.Min
+	sr = sr.Intersect(b.Bounds())
+	if sr.Empty() {
+		return
+	}
+	dp = dp.Add(sr.Min.Sub(originalSRMin))
+	b.preUpload()
+
+	err := b.putImage(xd, xg, depth, dp, sr)
+	if err != nil {
+		log.Printf("x11driver: xproto.PutImage: %v", err)
+	}
+}
+
+// request xproto.PutImage in batches
+func (b *bufferFailbackImpl) putImage(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle) error {
+	widthPerReq := b.size.X
+	rowPerReq := xPutImageReqDataSize / (widthPerReq * 4)
+	dataPerReq := rowPerReq * widthPerReq * 4
+	dstX := dp.X
+	dstY := dp.Y
+	start := 0
+	end := 0
+
+	var heightPerReq int
+	var data []byte
+
+	for end < len(b.buf) {
+		end = start + dataPerReq
+		if end > len(b.buf) {
+			end = len(b.buf)
+		}
+
+		data = b.buf[start:end]
+		heightPerReq = len(data) / 4 / widthPerReq
+
+		err := xproto.PutImageChecked(
+			b.xc, xproto.ImageFormatZPixmap, xd, xg,
+			uint16(widthPerReq), uint16(heightPerReq),
+			int16(dstX), int16(dstY),
+			0, depth, data).Check()
+		if err != nil {
+			return err
+		}
+
+		// prepare next request
+		start = end
+		dstY += rowPerReq
+	}
+
+	return nil
+}

--- a/shiny/driver/x11driver/buffer_fallback.go
+++ b/shiny/driver/x11driver/buffer_fallback.go
@@ -15,7 +15,7 @@ const (
 	xPutImageReqDataSize  = xPutImageReqSizeMax - xPutImageReqSizeFixed
 )
 
-type bufferFailbackImpl struct {
+type bufferFallbackImpl struct {
 	xc *xgb.Conn
 
 	buf  []byte
@@ -23,12 +23,12 @@ type bufferFailbackImpl struct {
 	size image.Point
 }
 
-func (b *bufferFailbackImpl) Release()                {}
-func (b *bufferFailbackImpl) Size() image.Point       { return b.size }
-func (b *bufferFailbackImpl) Bounds() image.Rectangle { return image.Rectangle{Max: b.size} }
-func (b *bufferFailbackImpl) RGBA() *image.RGBA       { return &b.rgba }
+func (b *bufferFallbackImpl) Release()                {}
+func (b *bufferFallbackImpl) Size() image.Point       { return b.size }
+func (b *bufferFallbackImpl) Bounds() image.Rectangle { return image.Rectangle{Max: b.size} }
+func (b *bufferFallbackImpl) RGBA() *image.RGBA       { return &b.rgba }
 
-func (b *bufferFailbackImpl) preUpload() {
+func (b *bufferFallbackImpl) preUpload() {
 	// Check that the program hasn't tried to modify the rgba field via the
 	// pointer returned by the bufferImpl.RGBA method. This check doesn't catch
 	// 100% of all cases; it simply tries to detect some invalid uses of a
@@ -41,7 +41,7 @@ func (b *bufferFailbackImpl) preUpload() {
 	swizzle.BGRA(b.buf)
 }
 
-func (b *bufferFailbackImpl) upload(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle) {
+func (b *bufferFallbackImpl) upload(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle) {
 	originalSRMin := sr.Min
 	sr = sr.Intersect(b.Bounds())
 	if sr.Empty() {
@@ -57,7 +57,7 @@ func (b *bufferFailbackImpl) upload(xd xproto.Drawable, xg xproto.Gcontext, dept
 }
 
 // request xproto.PutImage in batches
-func (b *bufferFailbackImpl) putImage(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle) error {
+func (b *bufferFallbackImpl) putImage(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle) error {
 	widthPerReq := b.size.X
 	rowPerReq := xPutImageReqDataSize / (widthPerReq * 4)
 	dataPerReq := rowPerReq * widthPerReq * 4

--- a/shiny/driver/x11driver/buffer_fallback.go
+++ b/shiny/driver/x11driver/buffer_fallback.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package x11driver
 
 import (
@@ -92,7 +96,7 @@ func (b *bufferFallbackImpl) upload(xd xproto.Drawable, xg xproto.Gcontext, dept
 	b.postUpload()
 }
 
-// request xproto.PutImage in batches
+// putImage issues xproto.PutImage requests in batches.
 func (b *bufferFallbackImpl) putImage(xd xproto.Drawable, xg xproto.Gcontext, depth uint8, dp image.Point, sr image.Rectangle) error {
 	widthPerReq := b.size.X
 	rowPerReq := xPutImageReqDataSize / (widthPerReq * 4)
@@ -102,17 +106,14 @@ func (b *bufferFallbackImpl) putImage(xd xproto.Drawable, xg xproto.Gcontext, de
 	start := 0
 	end := 0
 
-	var heightPerReq int
-	var data []byte
-
 	for end < len(b.buf) {
 		end = start + dataPerReq
 		if end > len(b.buf) {
 			end = len(b.buf)
 		}
 
-		data = b.buf[start:end]
-		heightPerReq = len(data) / 4 / widthPerReq
+		data := b.buf[start:end]
+		heightPerReq := len(data) / (widthPerReq * 4)
 
 		err := xproto.PutImageChecked(
 			b.xc, xproto.ImageFormatZPixmap, xd, xg,
@@ -123,7 +124,6 @@ func (b *bufferFallbackImpl) putImage(xd xproto.Drawable, xg xproto.Gcontext, de
 			return err
 		}
 
-		// prepare next request
 		start = end
 		dstY += rowPerReq
 	}

--- a/shiny/driver/x11driver/screen.go
+++ b/shiny/driver/x11driver/screen.go
@@ -62,15 +62,18 @@ type screenImpl struct {
 	windows         map[xproto.Window]*windowImpl
 	nPendingUploads int
 	completionKeys  []uint16
+
+	useShm bool
 }
 
-func newScreenImpl(xc *xgb.Conn) (*screenImpl, error) {
+func newScreenImpl(xc *xgb.Conn, useShm bool) (*screenImpl, error) {
 	s := &screenImpl{
 		xc:      xc,
 		xsi:     xproto.Setup(xc).DefaultScreen(xc),
 		buffers: map[shm.Seg]*bufferImpl{},
 		uploads: map[uint16]chan struct{}{},
 		windows: map[xproto.Window]*windowImpl{},
+		useShm:  useShm,
 	}
 	if err := s.initAtoms(); err != nil {
 		return nil, err
@@ -282,12 +285,26 @@ const (
 )
 
 func (s *screenImpl) NewBuffer(size image.Point) (retBuf screen.Buffer, retErr error) {
-	// TODO: detect if the X11 server or connection cannot support SHM pixmaps,
-	// and fall back to regular pixmaps.
 
 	w, h := int64(size.X), int64(size.Y)
 	if w < 0 || maxShmSide < w || h < 0 || maxShmSide < h || maxShmSize < 4*w*h {
 		return nil, fmt.Errorf("x11driver: invalid buffer size %v", size)
+	}
+
+	// if the X11 server or connection cannot support SHM pixmaps,
+	// fall back to regular pixmaps.
+	if !s.useShm {
+		b := &bufferFailbackImpl{
+			xc:   s.xc,
+			size: size,
+			rgba: image.RGBA{
+				Stride: 4 * size.X,
+				Rect:   image.Rectangle{Max: size},
+				Pix:    make([]uint8, 4*size.X*size.Y),
+			},
+		}
+		b.buf = b.rgba.Pix
+		return b, nil
 	}
 
 	b := &bufferImpl{

--- a/shiny/driver/x11driver/screen.go
+++ b/shiny/driver/x11driver/screen.go
@@ -294,7 +294,7 @@ func (s *screenImpl) NewBuffer(size image.Point) (retBuf screen.Buffer, retErr e
 	// if the X11 server or connection cannot support SHM pixmaps,
 	// fall back to regular pixmaps.
 	if !s.useShm {
-		b := &bufferFailbackImpl{
+		b := &bufferFallbackImpl{
 			xc:   s.xc,
 			size: size,
 			rgba: image.RGBA{

--- a/shiny/driver/x11driver/screen.go
+++ b/shiny/driver/x11driver/screen.go
@@ -51,6 +51,7 @@ type screenImpl struct {
 
 	// opaqueP is a fully opaque, solid fill picture.
 	opaqueP render.Picture
+	useShm  bool
 
 	uniformMu sync.Mutex
 	uniformC  render.Color
@@ -62,8 +63,6 @@ type screenImpl struct {
 	windows         map[xproto.Window]*windowImpl
 	nPendingUploads int
 	completionKeys  []uint16
-
-	useShm bool
 }
 
 func newScreenImpl(xc *xgb.Conn, useShm bool) (*screenImpl, error) {
@@ -291,7 +290,7 @@ func (s *screenImpl) NewBuffer(size image.Point) (retBuf screen.Buffer, retErr e
 		return nil, fmt.Errorf("x11driver: invalid buffer size %v", size)
 	}
 
-	// if the X11 server or connection cannot support SHM pixmaps,
+	// If the X11 server or connection cannot support SHM pixmaps,
 	// fall back to regular pixmaps.
 	if !s.useShm {
 		b := &bufferFallbackImpl{

--- a/shiny/driver/x11driver/texture.go
+++ b/shiny/driver/x11driver/texture.go
@@ -59,7 +59,7 @@ func (t *textureImpl) Upload(dp image.Point, src screen.Buffer, sr image.Rectang
 	if t.degenerate() {
 		return
 	}
-	src.(*bufferImpl).upload(xproto.Drawable(t.xm), t.s.gcontext32, textureDepth, dp, sr)
+	src.(bufferUploader).upload(xproto.Drawable(t.xm), t.s.gcontext32, textureDepth, dp, sr)
 }
 
 func (t *textureImpl) Fill(dr image.Rectangle, src color.Color, op draw.Op) {

--- a/shiny/driver/x11driver/window.go
+++ b/shiny/driver/x11driver/window.go
@@ -67,7 +67,7 @@ func (w *windowImpl) Release() {
 }
 
 func (w *windowImpl) Upload(dp image.Point, src screen.Buffer, sr image.Rectangle) {
-	src.(*bufferImpl).upload(xproto.Drawable(w.xw), w.xg, w.s.xsi.RootDepth, dp, sr)
+	src.(bufferUploader).upload(xproto.Drawable(w.xw), w.xg, w.s.xsi.RootDepth, dp, sr)
 }
 
 func (w *windowImpl) Fill(dr image.Rectangle, src color.Color, op draw.Op) {

--- a/shiny/driver/x11driver/x11driver.go
+++ b/shiny/driver/x11driver/x11driver.go
@@ -47,11 +47,13 @@ func main(f func(screen.Screen)) (retErr error) {
 	if err := render.Init(xc); err != nil {
 		return fmt.Errorf("x11driver: render.Init failed: %v", err)
 	}
+
+	useShm := true
 	if err := shm.Init(xc); err != nil {
-		return fmt.Errorf("x11driver: shm.Init failed: %v", err)
+		useShm = false
 	}
 
-	s, err := newScreenImpl(xc)
+	s, err := newScreenImpl(xc, useShm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR implement the **TODO** in buffer.go:
```
// TODO: detect if the X11 server or connection cannot support SHM pixmaps,
// and fall back to regular pixmaps.
```
It fixes the issues:
[golang/go#15100](https://github.com/golang/go/issues/15100)
[aarzilli/gdlv#26](https://github.com/aarzilli/gdlv/issues/26)
[aarzilli/gdlv#5](https://github.com/aarzilli/gdlv/issues/5)
[oakmound/shiny#8](https://github.com/oakmound/shiny/issues/8)

@sbinet
@aarzilli 
@200sc