### PR TITLE
ebnf: support raw string tokens as used by EBNF in the Go spec

### DIFF
--- a/ebnf/ebnf_test.go
+++ b/ebnf/ebnf_test.go
@@ -30,6 +30,8 @@ var goodGrammars = []string{
 	 La = "a" .
 	 Ti = ti .
 	 ti = "b" .`,
+
+	"Program = `\"` .",
 }
 
 var badGrammars = []string{

--- a/ebnf/parser.go
+++ b/ebnf/parser.go
@@ -60,7 +60,7 @@ func (p *parser) parseIdentifier() *Name {
 func (p *parser) parseToken() *Token {
 	pos := p.pos
 	value := ""
-	if p.tok == scanner.String {
+	if p.tok == scanner.String || p.tok == scanner.RawString {
 		value, _ = strconv.Unquote(p.lit)
 		// Unquote may fail with an error, but only if the scanner found
 		// an illegal string in the first place. In this case the error
@@ -80,7 +80,7 @@ func (p *parser) parseTerm() (x Expression) {
 	case scanner.Ident:
 		x = p.parseIdentifier()
 
-	case scanner.String:
+	case scanner.String, scanner.RawString:
 		tok := p.parseToken()
 		x = tok
 		const ellipsis = '…' // U+2026, the horizontal ellipsis character

--- a/ebnflint/ebnflint_test.go
+++ b/ebnflint/ebnflint_test.go
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Doesn't work from Go 1.11 on, so...
-// +build !go1.11
-
 package main
 
 import (


### PR DESCRIPTION
The EBNF in the Go specification uses raw strings for tokens that
contain double quotes or backslashes. This change adds support
for raw string tokens to the ebnf package, so that go_spec.html
is validated successfully.

This change also re-enables the ebnflint test, which validates the
Go spec.

Fixes golang/go#37290