### PR TITLE
Fix wrong condition in x11key Lookup for ASCII code

### DIFF
--- a/shiny/driver/internal/x11key/x11key.go
+++ b/shiny/driver/internal/x11key/x11key.go
@@ -63,7 +63,7 @@ func (t *KeysymTable) Lookup(detail uint8, state uint16) (rune, key.Code) {
 
 	// The key event's code is independent of whether the shift key is down.
 	var c key.Code
-	if 0 <= unshifted && unshifted < 0x80 {
+	if 0 >= unshifted && unshifted < 0x80 {
 		c = asciiKeycodes[unshifted]
 		if state&LockMask != 0 {
 			r = unicode.ToUpper(r)


### PR DESCRIPTION
* the condition was never met because rune is usually unsigned int
* the logical result of checking whether unshifted key rune is ASCII is range from 0 to 0x80