### PR TITLE
Mz unicode

### DIFF
--- a/shiny/driver/internal/x11key/x11key.go
+++ b/shiny/driver/internal/x11key/x11key.go
@@ -63,7 +63,7 @@ func (t *KeysymTable) Lookup(detail uint8, state uint16) (rune, key.Code) {
 
 	// The key event's code is independent of whether the shift key is down.
 	var c key.Code
-	if 0 <= unshifted && unshifted < 0x80 {
+	if 0 >= unshifted && unshifted < 0x80 {
 		c = asciiKeycodes[unshifted]
 		if state&LockMask != 0 {
 			r = unicode.ToUpper(r)

--- a/shiny/driver/internal/x11key/x11key.go
+++ b/shiny/driver/internal/x11key/x11key.go
@@ -4,7 +4,7 @@
 
 //go:generate go run gen.go
 
-// x11key contains X11 numeric codes for the keyboard and mouse.
+// Package x11key contains X11 numeric codes for the keyboard and mouse.
 package x11key // import "golang.org/x/exp/shiny/driver/internal/x11key"
 
 import (
@@ -30,12 +30,14 @@ const (
 	Button5Mask = 1 << 12
 )
 
+// KeysymTable holds current table of keyboard keys mapped to Xkb keysyms & current special modifiers bits
 type KeysymTable struct {
 	Table [256][6]uint32
 
 	NumLockMod, ModeSwitchMod, ISOLevel3ShiftMod uint16
 }
 
+// Lookup converts Xkb xproto keycode (detail) & mod (state) into mobile/event/key Rune & Code
 func (t *KeysymTable) Lookup(detail uint8, state uint16) (rune, key.Code) {
 	te := t.Table[detail][0:2]
 	if state&t.ModeSwitchMod != 0 {
@@ -86,6 +88,7 @@ func isKeypad(keysym uint32) bool {
 	return keysym >= 0xff80 && keysym <= 0xffbd
 }
 
+// KeyModifiers returns mobile/event/key modifiers type from xproto mod state
 func KeyModifiers(state uint16) (m key.Modifiers) {
 	if state&ShiftMask != 0 {
 		m |= key.ModShift

--- a/shiny/driver/internal/x11key/x11key.go
+++ b/shiny/driver/internal/x11key/x11key.go
@@ -104,6 +104,8 @@ func KeyModifiers(state uint16) (m key.Modifiers) {
 
 // These constants come from /usr/include/X11/{keysymdef,XF86keysym}.h
 const (
+	xkISOLevel3Shift = 0xfe03
+
 	xkISOLeftTab = 0xfe20
 	xkBackSpace  = 0xff08
 	xkTab        = 0xff09
@@ -183,6 +185,8 @@ const (
 // that do not correspond to a Unicode code point, such as "Page Up", "F1" or
 // "Left Shift", to key.Code values.
 var nonUnicodeKeycodes = map[rune]key.Code{
+	xkISOLevel3Shift: key.CodeRightAlt,
+
 	xkISOLeftTab: key.CodeTab,
 	xkBackSpace:  key.CodeDeleteBackspace,
 	xkTab:        key.CodeTab,


### PR DESCRIPTION
 Add missing XK ISO Level 3 shift non unicode char in x11key map

* The most appropriate description here: https://unix.stackexchange.com/a/55154/440266
* Right Alt ~ AltGr ~ ISO level 3 shift (but just for back compatibility)
* in new sense the SwitchMode is replaced by XK_ISO_Group_Shift and aliases in some languages (keyboard layouts)

Add missing methods descriptions 