### PR TITLE
mmap: use unsafe.Slice rather than maxBytes array

### DIFF
--- a/mmap/mmap_windows.go
+++ b/mmap/mmap_windows.go
@@ -108,7 +108,7 @@ func Open(filename string) (*ReaderAt, error) {
 	if err != nil {
 		return nil, err
 	}
-	data := (*[maxBytes]byte)(unsafe.Pointer(ptr))[:size]
+	data := unsafe.Slice((*byte)(unsafe.Pointer(ptr)), size)
 
 	r := &ReaderAt{data: data}
 	if debug {

--- a/mmap/mmap_windows_386.go
+++ b/mmap/mmap_windows_386.go
@@ -1,7 +1,0 @@
-// Copyright 2018 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-package mmap
-
-const maxBytes = 1<<31 - 1

--- a/mmap/mmap_windows_amd64.go
+++ b/mmap/mmap_windows_amd64.go
@@ -1,7 +1,0 @@
-// Copyright 2018 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-package mmap
-
-const maxBytes = 1<<50 - 1


### PR DESCRIPTION
Fixes golang/go#49106