### PR TITLE
mmap: fix undefined maxBytes for windows/arm64

### DIFF
--- a/mmap/mmap_windows_arm64.go
+++ b/mmap/mmap_windows_arm64.go
@@ -1,0 +1,7 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mmap
+
+const maxBytes = 1<<50 - 1


### PR DESCRIPTION
﻿Fixes: golang/go#49106
