### PR TITLE
slices: improve the performance of Equal

### DIFF
--- a/slices/slices.go
+++ b/slices/slices.go
@@ -18,9 +18,8 @@ func Equal[E comparable](s1, s2 []E) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
-	for i, v1 := range s1 {
-		v2 := s2[i]
-		if v1 != v2 {
+	for i := range s1 {
+		if s1[i] != s2[i] {
 			return false
 		}
 	}


### PR DESCRIPTION
Although it does an additional index operation, but it avoids the value copy of the range loop,
and it will has a better performance if E is a large structure.

Compares two int slices, the slices length are 10:
name                old time/op  new time/op  delta
Equal_WithIntSlices  5.80ns ± 0%  5.80ns ± 1%   ~     (p=0.889 n=14+15)

Compares two string slices, the slices length are 10:
name                   old time/op  new time/op  delta
Equal_WithStringSlices  17.6ns ± 1%  16.6ns ± 0%  -5.61%  (p=0.000 n=15+15)

Compares two runtime.MemStats slices, the slices length are 10:
name                        old time/op  new time/op  delta
Equal_WithLagerStructSlices  4.46µs ± 0%  1.53µs ± 1%  -65.67%  (p=0.000 n=15+15)