### PR TITLE
slices: improve the performance of Index

### DIFF
--- a/slices/slices.go
+++ b/slices/slices.go
@@ -100,8 +100,8 @@ func CompareFunc[E1, E2 any](s1 []E1, s2 []E2, cmp func(E1, E2) int) int {
 // Index returns the index of the first occurrence of v in s,
 // or -1 if not present.
 func Index[E comparable](s []E, v E) int {
-	for i, vs := range s {
-		if v == vs {
+	for i := range s {
+		if v == s[i] {
 			return i
 		}
 	}


### PR DESCRIPTION
Benchmark with first index 10 / 10000 on int / string / runtime.MemStats slice:
name                           old time/op  new time/op  delta
Index_Int_10                3.60ns ± 0%  3.60ns ± 0%   ~     (p=0.349 n=15+15)
Index_Int_10000          2.27µs ± 0%  2.28µs ± 0%   ~     (p=0.451 n=14+14)

Index_String_10             9.19ns ± 0%  6.79ns ± 0%  -26.10%  (p=0.000 n=15+15)
Index_String_10000       6.75µs ± 0%  4.51µs ± 0%  -33.21%  (p=0.000 n=15+14)

Index_LargeStruct_10        2.94µs ± 0%  1.28µs ± 0%  -56.49%  (p=0.000 n=15+15)
Index_LargeStruct_10000  4.59ms ± 1%  2.26ms ± 1%  -50.78%  (p=0.000 n=13+15)