### PR TITLE
slices: relax the constraints to type whose underlying type is slice

### DIFF
--- a/slices/slices.go
+++ b/slices/slices.go
@@ -14,7 +14,7 @@ import "constraints"
 // Otherwise, the elements are compared in increasing index order, and the
 // comparison stops at the first unequal pair.
 // Floating point NaNs are not considered equal.
-func Equal[E comparable](s1, s2 []E) bool {
+func Equal[S ~[]E, E comparable](s1, s2 S) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
@@ -31,7 +31,7 @@ func Equal[E comparable](s1, s2 []E) bool {
 // EqualFunc returns false. Otherwise, the elements are compared in
 // increasing index order, and the comparison stops at the first index
 // for which eq returns false.
-func EqualFunc[E1, E2 any](s1 []E1, s2 []E2, eq func(E1, E2) bool) bool {
+func EqualFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](s1 S1, s2 S2, eq func(E1, E2) bool) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
@@ -52,7 +52,7 @@ func EqualFunc[E1, E2 any](s1 []E1, s2 []E2, eq func(E1, E2) bool) bool {
 // considered less than the longer one.
 // The result is 0 if s1 == s2, -1 if s1 < s2, and +1 if s1 > s2.
 // Comparisons involving floating point NaNs are ignored.
-func Compare[E constraints.Ordered](s1, s2 []E) int {
+func Compare[S ~[]E, E constraints.Ordered](s1, s2 []E) int {
 	s2len := len(s2)
 	for i, v1 := range s1 {
 		if i >= s2len {
@@ -79,7 +79,7 @@ func Compare[E constraints.Ordered](s1, s2 []E) int {
 // The result is the first non-zero result of cmp; if cmp always
 // returns 0 the result is 0 if len(s1) == len(s2), -1 if len(s1) < len(s2),
 // and +1 if len(s1) > len(s2).
-func CompareFunc[E1, E2 any](s1 []E1, s2 []E2, cmp func(E1, E2) int) int {
+func CompareFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](s1 S1, s2 S2, cmp func(E1, E2) int) int {
 	s2len := len(s2)
 	for i, v1 := range s1 {
 		if i >= s2len {
@@ -98,7 +98,7 @@ func CompareFunc[E1, E2 any](s1 []E1, s2 []E2, cmp func(E1, E2) int) int {
 
 // Index returns the index of the first occurrence of v in s,
 // or -1 if not present.
-func Index[E comparable](s []E, v E) int {
+func Index[S ~[]E, E comparable](s S, v E) int {
 	for i, vs := range s {
 		if v == vs {
 			return i
@@ -109,7 +109,7 @@ func Index[E comparable](s []E, v E) int {
 
 // IndexFunc returns the first index i satisfying f(s[i]),
 // or -1 if none do.
-func IndexFunc[E any](s []E, f func(E) bool) int {
+func IndexFunc[S ~[]E, E any](s S, f func(E) bool) int {
 	for i, v := range s {
 		if f(v) {
 			return i
@@ -119,7 +119,7 @@ func IndexFunc[E any](s []E, f func(E) bool) int {
 }
 
 // Contains reports whether v is present in s.
-func Contains[E comparable](s []E, v E) bool {
+func Contains[S ~[]E, E comparable](s S, v E) bool {
 	return Index(s, v) >= 0
 }
 

--- a/slices/sort.go
+++ b/slices/sort.go
@@ -7,26 +7,28 @@ package slices
 import "constraints"
 
 // Sort sorts a slice of any ordered type in ascending order.
-func Sort[Elem constraints.Ordered](x []Elem) {
+func Sort[S ~[]E, E constraints.Ordered](x S) {
 	n := len(x)
-	quickSortOrdered(x, 0, n, maxDepth(n))
+	// Due to golang/go#48619, constraints of quickSortOrdered and its related
+	// functsions are not changed. So cast S to []E for now.
+	quickSortOrdered([]E(x), 0, n, maxDepth(n))
 }
 
 // Sort sorts the slice x in ascending order as determined by the less function.
 // This sort is not guaranteed to be stable.
-func SortFunc[Elem any](x []Elem, less func(a, b Elem) bool) {
+func SortFunc[S ~[]E, E any](x S, less func(a, b E) bool) {
 	n := len(x)
 	quickSortLessFunc(x, 0, n, maxDepth(n), less)
 }
 
 // SortStable sorts the slice x while keeping the original order of equal
 // elements, using less to compare elements.
-func SortStableFunc[Elem any](x []Elem, less func(a, b Elem) bool) {
+func SortStableFunc[S ~[]E, E any](x S, less func(a, b E) bool) {
 	stableLessFunc(x, len(x), less)
 }
 
 // IsSorted reports whether x is sorted in ascending order.
-func IsSorted[Elem constraints.Ordered](x []Elem) bool {
+func IsSorted[S ~[]E, E constraints.Ordered](x S) bool {
 	for i := len(x) - 1; i > 0; i-- {
 		if x[i] < x[i-1] {
 			return false
@@ -37,7 +39,7 @@ func IsSorted[Elem constraints.Ordered](x []Elem) bool {
 
 // IsSortedFunc reports whether x is sorted in ascending order, with less as the
 // comparison function.
-func IsSortedFunc[Elem any](x []Elem, less func(a, b Elem) bool) bool {
+func IsSortedFunc[S ~[]E, E any](x S, less func(a, b E) bool) bool {
 	for i := len(x) - 1; i > 0; i-- {
 		if less(x[i], x[i-1]) {
 			return false
@@ -51,7 +53,7 @@ func IsSortedFunc[Elem any](x []Elem, less func(a, b Elem) bool) bool {
 // which it could be inserted into the slice is returned; therefore, if the
 // intention is to find target itself a separate check for equality with the
 // element at the returned index is required.
-func BinarySearch[Elem constraints.Ordered](x []Elem, target Elem) int {
+func BinarySearch[S ~[]E, E constraints.Ordered](x S, target E) int {
 	return search(len(x), func(i int) bool { return x[i] >= target })
 }
 
@@ -63,7 +65,7 @@ func BinarySearch[Elem constraints.Ordered](x []Elem, target Elem) int {
 // the first true index. If there is no such index, BinarySearchFunc returns n.
 // (Note that the "not found" return value is not -1 as in, for instance,
 // strings.Index.) Search calls ok(i) only for i in the range [0, n).
-func BinarySearchFunc[Elem any](x []Elem, ok func(Elem) bool) int {
+func BinarySearchFunc[S ~[]E, E any](x S, ok func(E) bool) int {
 	return search(len(x), func(i int) bool { return ok(x[i]) })
 }
 

--- a/slices/zsortfunc.go
+++ b/slices/zsortfunc.go
@@ -7,7 +7,7 @@
 package slices
 
 // insertionSortLessFunc sorts data[a:b] using insertion sort.
-func insertionSortLessFunc[Elem any](data []Elem, a, b int, less func(a, b Elem) bool) {
+func insertionSortLessFunc[S ~[]E, E any](data S, a, b int, less func(a, b E) bool) {
 	for i := a + 1; i < b; i++ {
 		for j := i; j > a && less(data[j], data[j-1]); j-- {
 			data[j], data[j-1] = data[j-1], data[j]
@@ -17,7 +17,7 @@ func insertionSortLessFunc[Elem any](data []Elem, a, b int, less func(a, b Elem)
 
 // siftDownLessFunc implements the heap property on data[lo:hi].
 // first is an offset into the array where the root of the heap lies.
-func siftDownLessFunc[Elem any](data []Elem, lo, hi, first int, less func(a, b Elem) bool) {
+func siftDownLessFunc[S ~[]E, E any](data S, lo, hi, first int, less func(a, b E) bool) {
 	root := lo
 	for {
 		child := 2*root + 1
@@ -35,7 +35,7 @@ func siftDownLessFunc[Elem any](data []Elem, lo, hi, first int, less func(a, b E
 	}
 }
 
-func heapSortLessFunc[Elem any](data []Elem, a, b int, less func(a, b Elem) bool) {
+func heapSortLessFunc[S ~[]E, E any](data S, a, b int, less func(a, b E) bool) {
 	first := a
 	lo := 0
 	hi := b - a
@@ -56,7 +56,7 @@ func heapSortLessFunc[Elem any](data []Elem, a, b int, less func(a, b Elem) bool
 // "Engineering a Sort Function" SP&E November 1993.
 
 // medianOfThreeLessFunc moves the median of the three values data[m0], data[m1], data[m2] into data[m1].
-func medianOfThreeLessFunc[Elem any](data []Elem, m1, m0, m2 int, less func(a, b Elem) bool) {
+func medianOfThreeLessFunc[S ~[]E, E any](data S, m1, m0, m2 int, less func(a, b E) bool) {
 	// sort 3 elements
 	if less(data[m1], data[m0]) {
 		data[m1], data[m0] = data[m0], data[m1]
@@ -72,13 +72,13 @@ func medianOfThreeLessFunc[Elem any](data []Elem, m1, m0, m2 int, less func(a, b
 	// now data[m0] <= data[m1] <= data[m2]
 }
 
-func swapRangeLessFunc[Elem any](data []Elem, a, b, n int, less func(a, b Elem) bool) {
+func swapRangeLessFunc[S ~[]E, E any](data S, a, b, n int, less func(a, b E) bool) {
 	for i := 0; i < n; i++ {
 		data[a+i], data[b+i] = data[b+i], data[a+i]
 	}
 }
 
-func doPivotLessFunc[Elem any](data []Elem, lo, hi int, less func(a, b Elem) bool) (midlo, midhi int) {
+func doPivotLessFunc[S ~[]E, E any](data S, lo, hi int, less func(a, b E) bool) (midlo, midhi int) {
 	m := int(uint(lo+hi) >> 1) // Written like this to avoid integer overflow.
 	if hi-lo > 40 {
 		// Tukey's "Ninther" median of three medians of three.
@@ -165,7 +165,7 @@ func doPivotLessFunc[Elem any](data []Elem, lo, hi int, less func(a, b Elem) boo
 	return b - 1, c
 }
 
-func quickSortLessFunc[Elem any](data []Elem, a, b, maxDepth int, less func(a, b Elem) bool) {
+func quickSortLessFunc[S ~[]E, E any](data S, a, b, maxDepth int, less func(a, b E) bool) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
 			heapSortLessFunc(data, a, b, less)
@@ -195,7 +195,7 @@ func quickSortLessFunc[Elem any](data []Elem, a, b, maxDepth int, less func(a, b
 	}
 }
 
-func stableLessFunc[Elem any](data []Elem, n int, less func(a, b Elem) bool) {
+func stableLessFunc[S ~[]E, E any](data S, n int, less func(a, b E) bool) {
 	blockSize := 20 // must be > 0
 	a, b := 0, blockSize
 	for b <= n {
@@ -238,7 +238,7 @@ func stableLessFunc[Elem any](data []Elem, n int, less func(a, b Elem) bool) {
 // symMerge assumes non-degenerate arguments: a < m && m < b.
 // Having the caller check this condition eliminates many leaf recursion calls,
 // which improves performance.
-func symMergeLessFunc[Elem any](data []Elem, a, m, b int, less func(a, b Elem) bool) {
+func symMergeLessFunc[S ~[]E, E any](data S, a, m, b int, less func(a, b E) bool) {
 	// Avoid unnecessary recursions of symMerge
 	// by direct insertion of data[a] into data[m:b]
 	// if data[a:m] only contains one element.
@@ -324,7 +324,7 @@ func symMergeLessFunc[Elem any](data []Elem, a, m, b int, less func(a, b Elem) b
 // Data of the form 'x u v y' is changed to 'x v u y'.
 // rotate performs at most b-a many calls to data.Swap,
 // and it assumes non-degenerate arguments: a < m && m < b.
-func rotateLessFunc[Elem any](data []Elem, a, m, b int, less func(a, b Elem) bool) {
+func rotateLessFunc[S ~[]E, E any](data S, a, m, b int, less func(a, b E) bool) {
 	i := m - a
 	j := b - m
 

--- a/slices/zsortordered.go
+++ b/slices/zsortordered.go
@@ -9,7 +9,7 @@ package slices
 import "constraints"
 
 // insertionSortOrdered sorts data[a:b] using insertion sort.
-func insertionSortOrdered[Elem constraints.Ordered](data []Elem, a, b int) {
+func insertionSortOrdered[E constraints.Ordered](data []E, a, b int) {
 	for i := a + 1; i < b; i++ {
 		for j := i; j > a && (data[j] < data[j-1]); j-- {
 			data[j], data[j-1] = data[j-1], data[j]
@@ -19,7 +19,7 @@ func insertionSortOrdered[Elem constraints.Ordered](data []Elem, a, b int) {
 
 // siftDownOrdered implements the heap property on data[lo:hi].
 // first is an offset into the array where the root of the heap lies.
-func siftDownOrdered[Elem constraints.Ordered](data []Elem, lo, hi, first int) {
+func siftDownOrdered[E constraints.Ordered](data []E, lo, hi, first int) {
 	root := lo
 	for {
 		child := 2*root + 1
@@ -37,7 +37,7 @@ func siftDownOrdered[Elem constraints.Ordered](data []Elem, lo, hi, first int) {
 	}
 }
 
-func heapSortOrdered[Elem constraints.Ordered](data []Elem, a, b int) {
+func heapSortOrdered[E constraints.Ordered](data []E, a, b int) {
 	first := a
 	lo := 0
 	hi := b - a
@@ -58,7 +58,7 @@ func heapSortOrdered[Elem constraints.Ordered](data []Elem, a, b int) {
 // "Engineering a Sort Function" SP&E November 1993.
 
 // medianOfThreeOrdered moves the median of the three values data[m0], data[m1], data[m2] into data[m1].
-func medianOfThreeOrdered[Elem constraints.Ordered](data []Elem, m1, m0, m2 int) {
+func medianOfThreeOrdered[E constraints.Ordered](data []E, m1, m0, m2 int) {
 	// sort 3 elements
 	if data[m1] < data[m0] {
 		data[m1], data[m0] = data[m0], data[m1]
@@ -74,13 +74,13 @@ func medianOfThreeOrdered[Elem constraints.Ordered](data []Elem, m1, m0, m2 int)
 	// now data[m0] <= data[m1] <= data[m2]
 }
 
-func swapRangeOrdered[Elem constraints.Ordered](data []Elem, a, b, n int) {
+func swapRangeOrdered[E constraints.Ordered](data []E, a, b, n int) {
 	for i := 0; i < n; i++ {
 		data[a+i], data[b+i] = data[b+i], data[a+i]
 	}
 }
 
-func doPivotOrdered[Elem constraints.Ordered](data []Elem, lo, hi int) (midlo, midhi int) {
+func doPivotOrdered[E constraints.Ordered](data []E, lo, hi int) (midlo, midhi int) {
 	m := int(uint(lo+hi) >> 1) // Written like this to avoid integer overflow.
 	if hi-lo > 40 {
 		// Tukey's "Ninther" median of three medians of three.
@@ -167,7 +167,7 @@ func doPivotOrdered[Elem constraints.Ordered](data []Elem, lo, hi int) (midlo, m
 	return b - 1, c
 }
 
-func quickSortOrdered[Elem constraints.Ordered](data []Elem, a, b, maxDepth int) {
+func quickSortOrdered[E constraints.Ordered](data []E, a, b, maxDepth int) {
 	for b-a > 12 { // Use ShellSort for slices <= 12 elements
 		if maxDepth == 0 {
 			heapSortOrdered(data, a, b)
@@ -197,7 +197,7 @@ func quickSortOrdered[Elem constraints.Ordered](data []Elem, a, b, maxDepth int)
 	}
 }
 
-func stableOrdered[Elem constraints.Ordered](data []Elem, n int) {
+func stableOrdered[E constraints.Ordered](data []E, n int) {
 	blockSize := 20 // must be > 0
 	a, b := 0, blockSize
 	for b <= n {
@@ -240,7 +240,7 @@ func stableOrdered[Elem constraints.Ordered](data []Elem, n int) {
 // symMerge assumes non-degenerate arguments: a < m && m < b.
 // Having the caller check this condition eliminates many leaf recursion calls,
 // which improves performance.
-func symMergeOrdered[Elem constraints.Ordered](data []Elem, a, m, b int) {
+func symMergeOrdered[E constraints.Ordered](data []E, a, m, b int) {
 	// Avoid unnecessary recursions of symMerge
 	// by direct insertion of data[a] into data[m:b]
 	// if data[a:m] only contains one element.
@@ -326,7 +326,7 @@ func symMergeOrdered[Elem constraints.Ordered](data []Elem, a, m, b int) {
 // Data of the form 'x u v y' is changed to 'x v u y'.
 // rotate performs at most b-a many calls to data.Swap,
 // and it assumes non-degenerate arguments: a < m && m < b.
-func rotateOrdered[Elem constraints.Ordered](data []Elem, a, m, b int) {
+func rotateOrdered[E constraints.Ordered](data []E, a, m, b int) {
 	i := m - a
 	j := b - m
 


### PR DESCRIPTION
Like what we done in exp/maps, exp/slices would be better to accept a
type whose underlying type is slice.

Due to golang/go#48619, constraints of quickSortOrdered and its
related functions are not changed. So cast S to []E for now.