### PR TITLE
proposal: generic/ranges: add range list get list of range numbers

### DIFF
--- a/ranges/range.go
+++ b/ranges/range.go
@@ -1,0 +1,30 @@
+package ranges
+
+import (
+	"math"
+)
+
+type rangeTypes interface {
+	int | int8 | int16 | int32 | int64 | uint | uint8 |
+		uint16 | uint32 | uint64 | float32 | float64
+}
+
+// RangeList return list of numbers between start and stop accourding step
+func RangeList[R rangeTypes](start, stop, step R) (list []R) {
+	if math.Signbit(float64(start)) || (start == 0) && math.Signbit(float64(stop)) && math.Signbit(float64(step)) {
+		for i := start; i > stop; i += step {
+			list = append(list, i)
+		}
+	} else if !math.Signbit(float64(start)) && !(start == 0) && math.Signbit(float64(stop)) && math.Signbit(float64(step)) {
+		return
+	} else if math.Signbit(float64(start)) || (start == 0) && !math.Signbit(float64(stop)) && math.Signbit(float64(step)) {
+		return
+	} else if math.Signbit(float64(start)) || (start == 0) && math.Signbit(float64(stop)) && !math.Signbit(float64(step)) {
+		return
+	} else {
+		for i := start; i < stop; i += step {
+			list = append(list, i)
+		}
+	}
+	return
+}

--- a/ranges/range_test.go
+++ b/ranges/range_test.go
@@ -1,0 +1,28 @@
+package ranges
+
+import (
+	"testing"
+)
+
+func TestRangeList(t *testing.T) {
+	wants := []struct {
+		Start, Stop, Step float64
+	}{
+		{0, 10, 1},
+		{0, -10, -1},
+		{-5, -125, -5},
+		{0, 0, 1},
+		{-1.5, -25.5, -1.5},
+		{1, 1, 0},
+	}
+
+	for _, want := range wants {
+		t.Log(RangeList(want.Start, want.Stop, want.Step))
+	}
+}
+
+func BenchmarkRangeList(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		RangeList(0, i, 1)
+	}
+}


### PR DESCRIPTION
The **RangeList** is inspired by python `list(range(0, 10, 1))`, which returns range numbers as int, uint and float

```go
package main

import (
	"fmt"
	"generic/ranges"
)

func main() {
	fmt.Println(ranges.RangeList(0, 10, 1))
}

// [0 1 2 3 4 5 6 7 8 9]

```

