### PR TITLE
slices: adds ChunkBy

### DIFF
--- a/slices/slices.go
+++ b/slices/slices.go
@@ -256,3 +256,20 @@ func Grow[S ~[]E, E any](s S, n int) S {
 func Clip[S ~[]E, E any](s S) S {
 	return s[:len(s):len(s)]
 }
+
+// ChunkBy takes values from s and and appends them to chunks
+// the appended values will have len <= n
+// if n is 0 default chunk size will be 1
+// if len s == 0 base type [][]T is returned with len == 0
+func ChunkBy[T any](s []T, n int) (chunks [][]T) {
+	if n == 0 {
+		n = 1
+	}
+	if len(s) == 0 {
+		return [][]T{}
+	}
+	for n < len(s) {
+		s, chunks = s[n:], append(chunks, s[0:n:n])
+	}
+	return append(chunks, s)
+}

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -6,6 +6,7 @@ package slices
 
 import (
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -766,4 +767,153 @@ func BenchmarkReplace(b *testing.B) {
 		})
 	}
 
+}
+
+func TestChunkBy(t *testing.T) {
+
+	type args struct {
+		s []string
+		n int
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantChunks [][]string
+	}{
+		{
+			name: "0 len slice 0 n",
+			args: args{
+				s: []string{},
+				n: 0,
+			},
+			wantChunks: [][]string{},
+		},
+		{
+			name: "1 len slice 0 n",
+			args: args{
+				s: []string{},
+				n: 0,
+			},
+			wantChunks: [][]string{},
+		},
+		{
+			name: "2 len slice 0 n",
+			args: args{
+				s: []string{"", ""},
+				n: 0,
+			},
+			wantChunks: [][]string{{""}, {""}},
+		},
+		{
+			name: "3 len slice 0 n",
+			args: args{
+				s: []string{"", "", ""},
+				n: 0,
+			},
+			wantChunks: [][]string{{""}, {""}, {""}},
+		},
+		{
+			name: "0 len slice 1 n",
+			args: args{
+				s: []string{},
+				n: 1,
+			},
+			wantChunks: [][]string{},
+		},
+		{
+			name: "1 len slice 1 n",
+			args: args{
+				s: []string{""},
+				n: 1,
+			},
+			wantChunks: [][]string{{""}},
+		},
+		{
+			name: "2 len slice 1 n",
+			args: args{
+				s: []string{"", ""},
+				n: 1,
+			},
+			wantChunks: [][]string{{""}, {""}},
+		},
+		{
+			name: "3 len slice 1 n",
+			args: args{
+				s: []string{"", "", ""},
+				n: 1,
+			},
+			wantChunks: [][]string{{""}, {""}, {""}},
+		},
+		{
+			name: "0 len slice 2 n",
+			args: args{
+				s: []string{},
+				n: 2,
+			},
+			wantChunks: [][]string{},
+		},
+		{
+			name: "1 len slice 2 n",
+			args: args{
+				s: []string{""},
+				n: 2,
+			},
+			wantChunks: [][]string{{""}},
+		},
+		{
+			name: "2 len slice 2 n",
+			args: args{
+				s: []string{"", ""},
+				n: 2,
+			},
+			wantChunks: [][]string{{"", ""}},
+		},
+		{
+			name: "3 len slice 2 n",
+			args: args{
+				s: []string{"", "", ""},
+				n: 2,
+			},
+			wantChunks: [][]string{{"", ""}, {""}},
+		},
+		{
+			name: "0 len slice 3 n",
+			args: args{
+				s: []string{},
+				n: 3,
+			},
+			wantChunks: [][]string{},
+		},
+		{
+			name: "1 len slice 3 n",
+			args: args{
+				s: []string{""},
+				n: 3,
+			},
+			wantChunks: [][]string{{""}},
+		},
+		{
+			name: "2 len slice 3 n",
+			args: args{
+				s: []string{"", ""},
+				n: 3,
+			},
+			wantChunks: [][]string{{"", ""}},
+		},
+		{
+			name: "3 len slice 3 n",
+			args: args{
+				s: []string{"", "", ""},
+				n: 3,
+			},
+			wantChunks: [][]string{{"", "", ""}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotChunks := ChunkBy(tt.args.s, tt.args.n); !reflect.DeepEqual(gotChunks, tt.wantChunks) {
+				t.Errorf("ChunkBy() = %v, want %v", gotChunks, tt.wantChunks)
+			}
+		})
+	}
 }


### PR DESCRIPTION
adds ChunkBy which accepts a slice and chunks the slice into segments of size <= given integer value

I find myself writing this function every time I start a new project as its necessary for batching api calls or distributing work to worker groups.

`
func ChunkBy[T any](s []T, n int) (chunks [][]T) 
`