### PR TITLE
slog: require go v1.19 for atomic.Int64 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.org/x/exp
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.8


### PR DESCRIPTION
https://github.com/golang/exp/blob/master/slog/level.go#L95 Here the type atomic.Int64 is being used...

atomic.Int64 was introduced in go v1.19, but the project level go.mod set 1.18 as its minimum requirement... hence people using slog on 1.18 face an error of atomic.Int64 not being declared
solves: https://github.com/golang/go/issues/57639