### PR TITLE
Add Count function to slices

### DIFF
--- a/slices/slices.go
+++ b/slices/slices.go
@@ -134,6 +134,17 @@ func ContainsFunc[E any](s []E, f func(E) bool) bool {
 	return IndexFunc(s, f) >= 0
 }
 
+// Count reports the number of items in s that are equal to v.
+func Count[E comparable](s []E, v E) int {
+	count := 0
+	for _, vs := range s {
+		if v == vs {
+			count += 1
+		}
+	}
+	return count
+}
+
 // Insert inserts the values v... into s at index i,
 // returning the modified slice.
 // In the returned slice r, r[i] == v[0].

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -377,6 +377,51 @@ func TestContainsFunc(t *testing.T) {
 	}
 }
 
+var countTests = []struct {
+	s    []int
+	v    int
+	want int
+}{
+	{
+		nil,
+		0,
+		0,
+	},
+	{
+		[]int{},
+		0,
+		0,
+	},
+	{
+		[]int{1, 2, 3},
+		4,
+		0,
+	},
+	{
+		[]int{1, 2, 3},
+		2,
+		1,
+	},
+	{
+		[]int{1, 2, 2, 3},
+		2,
+		2,
+	},
+	{
+		[]int{1, 2, 3, 2},
+		2,
+		2,
+	},
+}
+
+func TestCount(t *testing.T) {
+	for _, test := range countTests {
+		if got := Count(test.s, test.v); got != test.want {
+			t.Errorf("Count(%v, %v) = %v, want %v", test.s, test.v, got, test.want)
+		}
+	}
+}
+
 var insertTests = []struct {
 	s    []int
 	i    int


### PR DESCRIPTION
Adds a `Count()` function to the slices sub-library.

For an invocation `Count(a, b)`, will return the number of elements in `a` that are equal to the element `b`.
