### PR TITLE
slog: update value receiver names

### DIFF
--- a/slog/value.go
+++ b/slog/value.go
@@ -274,22 +274,22 @@ func (v Value) Bool() bool {
 	return v.bool()
 }
 
-func (a Value) bool() bool {
-	return a.num == 1
+func (v Value) bool() bool {
+	return v.num == 1
 }
 
 // Duration returns v's value as a time.Duration. It panics
 // if v is not a time.Duration.
-func (a Value) Duration() time.Duration {
-	if g, w := a.Kind(), KindDuration; g != w {
+func (v Value) Duration() time.Duration {
+	if g, w := v.Kind(), KindDuration; g != w {
 		panic(fmt.Sprintf("Value kind is %s, not %s", g, w))
 	}
 
-	return a.duration()
+	return v.duration()
 }
 
-func (a Value) duration() time.Duration {
-	return time.Duration(int64(a.num))
+func (v Value) duration() time.Duration {
+	return time.Duration(int64(v.num))
 }
 
 // Float64 returns v's value as a float64. It panics
@@ -302,8 +302,8 @@ func (v Value) Float64() float64 {
 	return v.float()
 }
 
-func (a Value) float() float64 {
-	return math.Float64frombits(a.num)
+func (v Value) float() float64 {
+	return math.Float64frombits(v.num)
 }
 
 // Time returns v's value as a time.Time. It panics


### PR DESCRIPTION
This change unifies the naming of the receivers in the value.go 
file (https://github.com/golang/exp/blob/master/slog/value.go). 

It also fixes the discrepancy between the doc comment 
("v's value") and the receiver's name for this function:
https://github.com/golang/exp/blob/d63ba01acd4b5892385c4390b334ea2c89f27eb7/slog/value.go#L281-L283
