### PR TITLE
add DefaultContext for slog

### DIFF
--- a/slog/context.go
+++ b/slog/context.go
@@ -1,0 +1,7 @@
+package slog
+
+type contextValKey int
+
+const (
+	defaultContextValKey contextValKey = iota
+)

--- a/slog/logger.go
+++ b/slog/logger.go
@@ -23,6 +23,18 @@ func init() {
 // Default returns the default Logger.
 func Default() *Logger { return defaultLogger.Load().(*Logger) }
 
+func DefaultOfContext(ctx context.Context) *Logger {
+	if v := ctx.Value(defaultContextValKey); v != nil {
+		return v.(*Logger)
+	} else {
+		return Default()
+	}
+}
+
+func NewContext(parent context.Context, l *Logger) context.Context {
+	return context.WithValue(parent, defaultContextValKey, l)
+}
+
 // SetDefault makes l the default Logger.
 // After this call, output from the log package's default Logger
 // (as with [log.Print], etc.) will be logged at LevelInfo using l's Handler.

--- a/slog/logger_test.go
+++ b/slog/logger_test.go
@@ -574,3 +574,13 @@ func TestPanics(t *testing.T) {
 		logBuf.Reset()
 	}
 }
+
+func TestContext(t *testing.T) {
+	logger := With("traceid", "123456")
+	ctx := context.Background()
+	ctx = NewContext(ctx, logger)
+	gotLogger := DefaultContext(ctx)
+	if gotLogger != logger {
+		t.Errorf("Logger is not equal in context value")
+	}
+}


### PR DESCRIPTION
I have some package in my project like: gorm , gin,  slog.  I don't want dependant on gorm and gin, How can i use traceid linked log content between gorm and gin module?

I want:

```go
package gin

func Request1(){

logger :=slog.With("traceid",123)
ctx:=context.Background()
ctx=slog.NewContext(ctx,logger)
gorm.ReadDB(ctx)
}

```

```go
package  gorm

func ReadDB(ctx context.Context){
     logger:=slog.DefaultContext(ctx)
    logger.Info("db is ready")
}

```

so, all modules can  write one attribute in one context , and don't need rewrite slog handle.

thanks


my proposal https://github.com/golang/go/issues/66168