### PR TITLE
shiny: adds loong64 to list of supported archs

### DIFF
--- a/shiny/driver/x11driver/shm_shmopen_syscall.go
+++ b/shiny/driver/x11driver/shm_shmopen_syscall.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux || dragonfly) && (amd64 || arm || arm64 || mips64 || mips64le)
+//go:build (linux || dragonfly) && (amd64 || arm || arm64 || mips64 || mips64le || loong64)
 
 package x11driver
 


### PR DESCRIPTION
Fixes golang/go#70855