### PR TITLE
cmd/gorelease: replace all self versions during load

### DIFF
--- a/cmd/gorelease/gorelease.go
+++ b/cmd/gorelease/gorelease.go
@@ -1082,7 +1082,7 @@ func prepareLoadDir(ctx context.Context, modFile *modfile.File, modPath, modRoot
 	f.AddModuleStmt("gorelease-load-module")
 	f.AddRequire(modPath, version)
 	if !cached {
-		f.AddReplace(modPath, version, modRoot, "")
+		f.AddReplace(modPath, "", modRoot, "")
 	}
 	if modFile != nil {
 		if modFile.Go != nil {


### PR DESCRIPTION
When a module has a transitive dependency on a higher version of itself,
minimal version selection can ignore the version-scoped replacement added by
prepareLoadDir and load the cached module instead of the local checkout.

Use a wildcard replacement so every selected version resolves to the local
module directory.

Fixes golang/go#80497